### PR TITLE
[WIP] add 'duffle cmd' sample section 

### DIFF
--- a/themes/duffle/layouts/index.html
+++ b/themes/duffle/layouts/index.html
@@ -31,17 +31,155 @@
       </div>
     </div>
 
-    <!-- <div class="height-full" id="features">
-      <div class="row row-full">
-        <div class="small-12 large-offset-2 large-8 end columns">
-          <h3 class="text-center">Features:</h3>
+    <div class="height-full" id="features">
+      <div class="row">
+        <div class="small-12 large-centered large-12 columns">
+          <h3 class="text-center">Functionality</h3>
+          <p class="subhead">Duffle commands at a glance.</p>
+          
+          <div class="tabs">
+            <input class="tab" type="radio" name="tabs" checked="checked" id="tab--1"/>
+            <label class="tab-button" for="tab--1" id="tab-button--1">
+              <h3>Duffle Build</h3>
+              <p>Builds the CNAB invocation image. When a Duffle app is multi-container, it also will build those images.</p>
+            </label>
+            <input class="tab" type="radio" name="tabs" id="tab--2"/>
+            <label class="tab-button" for="tab--2" id="tab-button--2">
+              <h3>Duffle Install</h3>
+              <p>Installs a bundle, using built-in Docker and OCI drivers.</p>
+            </label>
+            <input class="tab" type="radio" name="tabs" id="tab--3"/>
+            <label class="tab-button" for="tab--3" id="tab-button--3">
+              <h3>Duffle Push/Pull</h3>
+              <p>Push or pull a CNAB bundle to a repository.</p>
+            </label>
+            <input class="tab" type="radio" name="tabs" id="tab--4"/>
+            <label class="tab-button" for="tab--4" id="tab-button--4">
+              <h3>Duffle Sign</h3>
+              <p>Adds a cryptographic signature to a bundle, using OpenPGP</p>
+            </label>
+            <a href="https://github.com/deislabs/duffle/tree/master/docs" class="docs-link">Visit the docs for more <i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+            <div class="display" id="display--1">
+              <div class="code-wrap">
+                <p>
+                  <strong><i>$</i> duffle build ./examples/helloworld/ </strong><br/>
+                  &nbsp;&nbsp;Duffle Build Started: 'helloworld': 01CS02FNS3FTM9907V83GAQQMT<br/>
+                  &nbsp;&nbsp;helloworld: Building CNAB components: SUCCESS ⚓ &nbsp;(1.0090s)
+                </p>
+
+                <p>
+                  <strong><i>$</i> duffle credentials generate helloworld-creds -f examples/ 
+                    helloworld/cnab/bundle.json</strong><br/>
+                  &nbsp;&nbsp; name: helloworld-creds<br/>
+                  &nbsp;&nbsp;credentials:<br/>
+                  &nbsp;&nbsp;&nbsp;- name: quux<br/>
+                  &nbsp;&nbsp;&nbsp;- source:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value: EMPTY<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: pquux
+                </p>
+
+                <p>
+                  <strong><i>$</i> duffle install helloworld-demo -c helloworld-creds -f examples/helloworld/cnab/bundle.json</strong><br />
+                  Executing install action...<br /><br />
+                  Install action<br />
+                  Action install complete for helloworld-demo
+                </p>
+              </div>
+            </div>
+            <div class="display" id="display--2">
+              <div class="code-wrap">
+                <p>
+                  <strong><i>$</i> duffle build ./examples/helloworld/ </strong><br/>
+                  &nbsp;&nbsp;Duffle Build Started: 'helloworld': 01CS02FNS3FTM9907V83GAQQMT<br/>
+                  &nbsp;&nbsp;helloworld: Building CNAB components: SUCCESS ⚓ &nbsp;(1.0090s)
+                </p>
+
+                <p>
+                  <strong><i>$</i> duffle credentials generate helloworld-creds -f examples/ 
+                    helloworld/cnab/bundle.json</strong><br/>
+                  &nbsp;&nbsp; name: helloworld-creds<br/>
+                  &nbsp;&nbsp;credentials:<br/>
+                  &nbsp;&nbsp;&nbsp;- name: quux<br/>
+                  &nbsp;&nbsp;&nbsp;- source:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value: EMPTY<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: pquux
+                </p>
+
+                <p>
+                  <strong><i>$</i> duffle install helloworld-demo -c helloworld-creds -f examples/helloworld/cnab/bundle.json</strong><br />
+                  Executing install action...<br /><br />
+                  Install action<br />
+                  Action install complete for helloworld-demo
+                </p>
+              </div>
+            </div>
+            <div class="display" id="display--3">
+              <div class="code-wrap">
+                <p>
+                  <i>$</i> <strong>duffle build ./examples/helloworld/ </strong><br/>
+                  &nbsp;&nbsp;Duffle Build Started: 'helloworld': 01CS02FNS3FTM9907V83GAQQMT<br/>
+                  &nbsp;&nbsp;helloworld: Building CNAB components: SUCCESS ⚓ &nbsp;(1.0090s)
+                </p>
+
+                <p>
+                  <i>$</i> <strong>duffle credentials generate helloworld-creds -f examples/ 
+                    helloworld/cnab/bundle.json</strong><br/>
+                  &nbsp;&nbsp; name: helloworld-creds<br/>
+                  &nbsp;&nbsp;credentials:<br/>
+                  &nbsp;&nbsp;&nbsp;- name: quux<br/>
+                  &nbsp;&nbsp;&nbsp;- source:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value: EMPTY<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: pquux
+                </p>
+
+                <p>
+                  <i>$</i> <strong>duffle install helloworld-demo -c helloworld-creds -f examples/helloworld/cnab/bundle.json</strong><br />
+                  Executing install action...<br /><br />
+                  Install action<br />
+                  Action install complete for helloworld-demo
+                </p>
+              </div>
+            </div>
+            <div class="display" id="display--4">
+              <div class="code-wrap">
+                <p>
+                  <i>$</i> <strong>duffle build ./examples/helloworld/ </strong><br/>
+                  &nbsp;&nbsp;Duffle Build Started: 'helloworld': 01CS02FNS3FTM9907V83GAQQMT<br/>
+                  &nbsp;&nbsp;helloworld: Building CNAB components: SUCCESS ⚓ &nbsp;(1.0090s)
+                </p>
+
+                <p>
+                  <i>$</i> <strong>duffle credentials generate helloworld-creds -f examples/ 
+                    helloworld/cnab/bundle.json</strong><br/>
+                  &nbsp;&nbsp; name: helloworld-creds<br/>
+                  &nbsp;&nbsp;credentials:<br/>
+                  &nbsp;&nbsp;&nbsp;- name: quux<br/>
+                  &nbsp;&nbsp;&nbsp;- source:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value: EMPTY<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination:<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: pquux
+                </p>
+
+                <p>
+                  <i>$</i> <strong>duffle install helloworld-demo -c helloworld-creds -f examples/helloworld/cnab/bundle.json</strong><br />
+                  Executing install action...<br /><br />
+                  Install action<br />
+                  Action install complete for helloworld-demo
+                </p>
+              </div>
+            </div>
+          </div>
+      
         </div>
       </div>
             
       <div class="row row-full">
 
       </div>
-    </div> / features -->
+    </div> <!--/ features -->
     
     <div class="row row-full" id="credits">
       <div class="small-12 large-10 large-centered columns">

--- a/themes/duffle/layouts/partials/footer.html
+++ b/themes/duffle/layouts/partials/footer.html
@@ -17,6 +17,7 @@
     <div class="show-for-large-up large-2 columns"></div>
   </footer>
 
+  <!-- js for menu -->
   <script type="text/javascript">
     addMenuListener();
     function addMenuListener() {

--- a/themes/duffle/static/sass/styles.scss
+++ b/themes/duffle/static/sass/styles.scss
@@ -500,8 +500,183 @@ body.list {
 
 
 #features {
+  padding-top: 7.5rem;
+  padding-bottom: 5rem;
+
+  h3 {
+    margin: 3rem 0;
+  }
+
+  $content-height: 16rem; 
+
+  .tabs {
+    width: 100%;
+    min-height: $content-height;
+    position: relative;
+  }
   
+  .tab-height {
+    min-height: 4rem;
+  }
+  
+  .tab {
+    display: none;
+  }
+  
+  .tab-button {
+    margin: 0;
+    padding: 0.75rem 1rem 0.75rem 2.825rem;  
+    display: block;
+    position: relative;
+    width: 33.333%;
+    color: $navy;
+    border: 1px solid transparent;
+    cursor: pointer;
+    @include border-radius(.25rem, .25rem);
+    @extend .tab-height;
+    @include transition;
+
+    &:before,
+    &:after {
+      content: " ";
+      display: inline-block;
+      width: 0.25rem;
+      height: 3rem;
+      position: absolute;
+      top: 1.15rem;
+      left: 0.833rem;
+      background: lighten($bluel, 5%);
+      @include transition;
+    }
+
+    &:before {
+      @include border-radius(0.67rem, 0.67rem);
+      width: 0.67rem;
+      height: 0.67rem;
+    }
+
+    &:after {
+      top: 2.125rem;
+      left: 1rem;
+      height: auto;
+      bottom: 1rem;
+    }
+
+    h3 {
+      font-size: $base-font;
+      margin: 0 0 0.5rem;
+    }
+
+    p {
+      font-size: $base-sm;
+      line-height: 1.4;
+      margin: 0;
+    }
+
+    &:hover,
+    &.active,
+    &:active  {
+      background: lighten($bluel, 9.5%) !important;
+      border: 1px solid $bluel !important;
+
+      &:before,
+      &:after {
+        background-color: darken($bluel, 5%);
+      }
+    }
+  }
+
+  input[type="radio"]:checked + label {
+    background: lighten($bluel, 7.5%) !important;
+    border: 1px solid $bluel !important;
+
+    &:before {
+      background-color: $green;
+    }
+
+    &:after {
+      background-color: darken($bluel, 5%);
+    }
+  }
+
+  .docs-link {
+    position: absolute;
+    bottom: -3.25rem;
+    padding: 0 0 0 3rem;
+    color: $green;
+
+    &:before {
+      @include border-radius(0.67rem, 0.67rem);
+      @include transition;
+      content: " ";
+      display: inline-block;
+      width: 0.67rem;
+      height: 0.67rem;
+      position: absolute;
+      top: 0.6rem;
+      left: 0.833rem;
+      color: $bluel;
+      background: lighten($bluel, 5%);
+    }
+  }
+  
+  .display {
+    margin: 0;
+    padding:  0;
+    display: none;
+    position: absolute;
+    top: 0;
+    right: -1rem;
+    width: calc(100% - 33.333%);
+    height: 32rem;
+    overflow-y: scroll;
+    @include border-radius(.25rem, .25rem);
+    background: linear-gradient(to bottom right, rgb(240, 244, 251) 0%, rgb(223, 232, 246) 80%);
+  }
+
+  .code-wrap {
+    padding: 0rem 2rem 1rem;
+
+    p {
+      margin: 1rem 0;
+      padding: 0;
+      display: block;
+      position: relative;
+      height: auto;
+      color: lighten(desaturate($navy, 20%), 15%);
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: $base-sm;
+      line-height: 1.6;
+
+      strong {
+        font-weight: 400;
+        color: darken($navy, 7.5%);
+        margin-top: 2rem;
+        display: block;
+      }
+    }
+
+    i {
+      font-style: normal;
+      color: $green;
+      font-family: $workbold;
+    }
+  }
+  
+  #tab--1:checked ~ #tab-button--1,
+  #tab--2:checked ~ #tab-button--2,
+  #tab--3:checked ~ #tab-button--3,
+  #tab--4:checked ~ #tab-button--4 {
+    color: $navy;
+  }
+  #tab--1:checked ~ #display--1,
+  #tab--2:checked ~ #display--2,
+  #tab--3:checked ~ #display--3,
+  #tab--4:checked ~ #display--4 {
+    display: block;
+  }
 }
+
 
 #credits {
   padding-top: 8rem;


### PR DESCRIPTION
# Don't merge - work in progress.

This PR adds some code blocks to the duffle.sh site, to show some examples of what using Duffle looks like. Would be nice to get this section in for the launch, to include some technical detail in the marketing site.

--- 

![screen shot 2018-12-03 at 10 11 45 am](https://user-images.githubusercontent.com/686194/49392813-6149c100-f6e4-11e8-92dd-d1afc04a9f5f.png)

To Dos:

* [x] add a new section
* [x] hook up tabs javascript to toggle different code blocks
* [ ] add code examples
    * [x] duffle build
    * [x] duffle install
    * [ ] duffle push + pull
    * [ ] duffle sign
* [ ] optimize for mobile  